### PR TITLE
Number of changes on the sourcelib install script

### DIFF
--- a/tools/sourcelib_install.sh
+++ b/tools/sourcelib_install.sh
@@ -1,15 +1,38 @@
-sudo apt-get update
-sudo apt-get install -y gcc-arm-none-eabi	#Install ARM GCC EABI compiler
-sudo apt-get install -y gdb-arm-none-eabi
-sudo apt-get install -y libnewlib-arm-none-eabi	#Install ARM new library
-sudo apt-get install -y gitg		#Git management
-sudo apt-get install -y screen
-sudo apt-get remove modemmanager brltty	#Remove serial terminal interference
-sudo adduser $USER dialout		#Add user permissions for dialout
-sudo apt-get install -y python3-pip
-mkdir $HOME/Downloads
-wget -O $HOME/Downloads/JLink_Linux_V762_x86_64.deb https://cloudstor.aarnet.edu.au/plus/s/alRMOQKscp2JX74/download
-sudo dpkg -i $HOME/Downloads/JLink_Linux_V762_x86_64.deb
-sudo python3 -m pip install pylink-square
-sudo ln -s /usr/bin/gdb-multiarch /usr/local/bin/arm-none-eabi-gdb
+#!/bin/bash
+
+if hash apt 2>/dev/null; then
+  read -p "Install gcc and other arm utilities, screen & pip3. You will be asked to enter your password. Press enter to continue or ^C to cancel"
+  sudo apt update
+  sudo apt install -y gcc-arm-none-eabi	gdb-arm-none-eabi libnewlib-arm-none-eabi	gitg screen python3-pip
+  sudo apt remove modemmanager # Remove serial terminal interference
+  sudo adduser $USER dialout # Add user permissions for dialout
+  if [[ `uname -a` == *"x86_64"* ]]; then
+    read -p "Download & install JLink from the Segger website. Press enter to continue or ^C to cancel."
+    curl -d "accept_license_agreement=accepted" -X POST "https://www.segger.com/downloads/jlink/JLink_Linux_V762_x86_64.deb" --output /tmp/jlink.deb
+    sudo dpkg -i /tmp/jlink.deb
+  else
+    echo "This is not x86_64; not installing JLink. Do so yourself - download v7.62 from https://www.segger.com/downloads/jlink/"
+  fi
+  sudo ln -s /usr/bin/gdb-multiarch /usr/local/bin/arm-none-eabi-gdb
+
+elif hash dnf 2>/dev/null; then
+  print "You appear to be running Fedora. gitg (the git gui) and gdb will not be installed."
+  read -p "Install gcc and other arm utilities, screen & pip3. You will be asked to enter your password. Press enter to continue or ^C to cancel"
+  sudo dnf install arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs arm-none-eabi-newlib arm-none-eabi-gcc-cs-c++ screen python3-pip
+
+  if [[ `uname -a` == *"x86_64"* ]]; then
+    read -p "Download & install JLink from the Segger website. Press enter to continue or ^C to cancel."
+    curl -d "accept_license_agreement=accepted" -X POST "https://www.segger.com/downloads/jlink/JLink_Linux_V762_x86_64.rpm" --output /tmp/jlink.rpm
+    sudo rpm -i /tmp/jlink.rpm
+  else
+    echo "This is not x86_64; not installing JLink. Do so yourself - download v7.62 from https://www.segger.com/downloads/jlink/"
+  fi
+else
+  print "This script only supports Debian, Fedora and their derivatives."
+  exit 1
+
+fi
+
+read -p "Install python3 module pylink-square. Press enter to continue or ^C to cancel"
+pip3 install pylink-square
 /bin/bash $PWD/sourcelib_env_linux.sh


### PR DESCRIPTION
This makes a number of changes to sourcelib_install.sh:

1. Supports Fedora and its derivatives by using `dnf` when it detects its presence.
2. Prompts the user to confirm changes before making them to their system.
3. Downloads J-Link binaries directly from the Segger website rather than from a mirror. This also checks that the OS is x86_64 before downloading.
